### PR TITLE
Fixup/simplify key expiry validation

### DIFF
--- a/common.js
+++ b/common.js
@@ -37,17 +37,16 @@ function pubKeyHexIsValid (pubKeyHex, strict = false) {
       return false;
     }
 
-    const curYearTwoDigit = (new Date().getYear() - 100);
-
-    if (!(lastTwoDigitsNum > curYearTwoDigit - 2 && lastTwoDigitsNum < curYearTwoDigit + 1)) {
+    let today = Date.now();
+    let expiry = new Date(`${lastTwoDigitsNum}-${monthDigits}-1`); // node should do the right thing, even with a two digit year
+    expiry.setMonth(expiry.getMonth() + 1);
+    let twoYearsFromNow = new Date(new Date().setFullYear(new Date().getFullYear() + 2))
+    
+    if(today >= expiry){
       return false;
     }
 
-    if (strict && lastTwoDigitsNum !== curYearTwoDigit) {
-      return false;
-    }
-
-    if (strict && monthDigits > new Date().getMonth() + 1) {
+    if(expiry > twoYearsFromNow) {
       return false;
     }
 


### PR DESCRIPTION
Ahoy! I am working on a golang implementation of the spring83 protocol at motevets/springer, and I was testing my client against your server, but I was getting a 400 because the key was invalid.

My understanding of the rules are for a valid key when PUTting are:
- the expiry day must be greater than today
- the expiry day cannot be more than two years into the future

It looks like your implementation was asserting that the key expiry was the _same_ as the current year, when it would be valid for it to also be the next year if it was within the two year window.

Of course the protocol is new and shifting, and my understanding may be incomplete, but I hope this is helpful.