### PR TITLE
Tweaks to the docker-compose file

### DIFF
--- a/.local.env
+++ b/.local.env
@@ -1,0 +1,2 @@
+SPRING83_FQDN=spring83.example.com
+SPRING83_CONTACT_ADDR=spring83@example.com

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,14 +6,8 @@ services:
       dockerfile: Dockerfile
       target: serve
     network_mode: "host"
-    environment:
-      - SPRING83_FQDN=${SPRING83_FQDN}
-      - SPRING83_CONTACT_ADDR=${SPRING83_CONTACT_ADDR}
-    volumes: &default-logs-bind
-      - type: bind
-        source: ${SPRING83_CONTENT_DIR_HOST:?"Must define SPRING83_CONTENT_DIR_HOST as the absolute path to logs on the host."}
-        target: /content
+    env_file:
+      - .local.env
+    volumes: 
+      - ./content:/content
 
-volumes:
-  content:
-    external: true


### PR DESCRIPTION
I moved the environment variables into a file.
It would be nice to be able to define `SPRING83_CONTENT_DIR_HOST` in that env file too, but I wasn't able to easily get that to work. I just defined the volume and path directly in the docker-compose file. It's simpler but may not be as good as what was there before.